### PR TITLE
Request type as parameter for operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ AWS SDK for elm
 
 __Experimental: Work in progress__
 
-This repo contains scripts which read and translate the AWS SDK [apis/*.json][] files into an elm package. Eventually I will publish the generated code to the elm package repository.
+This repo contains scripts which read and translate the AWS SDK [apis/*.json][] files into an elm package. Eventually the generated code will be published to the elm package repository.
 
 ## Goals
 
-Not sure about the feasibility of the following, but these are my goals:
+These are the project goals:
 
 * Make this a pure elm implementation of the AWS SDK (no falling back to JavaScript AWS SDK)
 * Fully generated. No patching after the generation script is run.
@@ -19,19 +19,23 @@ Not sure about the feasibility of the following, but these are my goals:
 * [x] parse [apis/*.json][] files to get list of AWS APIs
 * [x] generate one elm module per AWS API
   * [x] module documentation
+* [ ] means to provide AWS credentials
 * [ ] generate AWS operations as elm functions
   * [x] function name
   * [x] function documentation
-  * [ ] function signature
-  * [ ] function implementation
+  * [x] function signature
+  * [x] decode response
+  * [ ] encode request body
+  * [ ] authentication header
 * [ ] generate AWS shapes as elm unions and records
   * [x] type name
   * [x] type documentation
-  * [ ] record type signature
+  * [x] record type signature
   * [x] union type signature
-  * [ ] better handling of nested union types
-  * [ ] better handling of non-string union types
-* [ ] not sure yet what else is involved...
+  * [x] better handling of non-string union types
+  * [ ] handle recursive types (like dynamodb `AttributeValue`)
+* [ ] misc.
+  * [ ] handle blob types
   * [ ] share common shapes as types between modules?
   * [ ] integration tests?
 

--- a/scripts/generate-sdk.js
+++ b/scripts/generate-sdk.js
@@ -11,7 +11,7 @@ if (!fs.existsSync(serviceRoot)) {
 }
 
 const sources = findLatestSources(serviceRoot)
-  .filter(source => /^([a-c]|data)/.test(source))
+  .filter(source => /^(?!(streams\.)?dynamo|elasticmap)/.test(source))
   .map((filename) => {
     const path = `${serviceRoot}/${filename}`;
     if (fs.existsSync(path)) {

--- a/scripts/process-service.js
+++ b/scripts/process-service.js
@@ -8,8 +8,17 @@ const { unique } = require('./util/set');
 
 const outRoot = sysPath.resolve(`${__dirname}/../src/AWS`);
 
+const findIOShapes = (ops, io) =>
+  Object.keys(ops).map((key) => {
+    const op = ops[key];
+    return op[io] && upCam(op[io].shape);
+  }).filter(x => x);
+
 module.exports = (data) => {
-  const types = resolveTypes(data.shapes);
+  const types = resolveTypes(data.shapes, {
+    inputShapes: findIOShapes(data.operations, 'input'),
+    outputShapes: findIOShapes(data.operations, 'output'),
+  });
   const mod = moduleName(data.metadata);
 
   const operations = Object.keys(data.operations)
@@ -38,7 +47,7 @@ module.exports = (data) => {
     'exception',
   ].map(key => ({
     key,
-    name: upCam(key),
+    name: `${upCam(key)}s`,
     types: types.filter(t => t.category === key),
   })).filter(c => c.types.length > 0);
 

--- a/scripts/util/case-conversions.js
+++ b/scripts/util/case-conversions.js
@@ -12,5 +12,7 @@ module.exports.upCam = (x) => {
   return y[0].toUpperCase() + y.slice(1);
 };
 
-module.exports.safeIdentifier = x =>
-  x.replace(/[^a-z0-9_]+/ig, '_');
+module.exports.safeIdentifier = x => x
+  .replace(/[^a-z0-9_]+/ig, '_')
+  .replace(/^(type|port)$/, '$1_')
+  ;

--- a/templates/api.dot
+++ b/templates/api.dot
@@ -9,7 +9,7 @@ module AWS.{{= it.mod }}
 ## Table of Contents
 
 * [Operations](#operations){{~ it.categories :c }}
-* [{{= c.name }}s](#{{= c.key }}s){{~}}
+* [{{= c.name }}](#{{= c.name.toLowerCase() }}){{~}}
 
 ## Operations
 
@@ -18,9 +18,9 @@ module AWS.{{= it.mod }}
 
 @docs {{= it.operations.map(op => op.name).join(',') }}
 {{~ it.categories :c }}
-## {{= c.name }}s
+## {{= c.name }}
 
-@docs {{= c.types.filter(t => t.exposeAs).map(t => t.name).join(',') }}
+@docs {{= c.types.filter(t => t.exposeAs).map(t => t.type).join(',') }}
 {{~}}
 -}
 
@@ -34,14 +34,20 @@ import Json.Decode.Pipeline as JDP
 {{~ it.operations :op }}
 
 {-| {{= op.doc }}
+{{? op.input && op.input.members }}
+__Parameters__
+
+{{~ op.input.members :m }}* `{{= m.key }}` __:__ `{{= m.value.type }}`
+{{~}}
+{{?}}
 -}
-{{= op.name }} : Http.Request {{= op.output.type }}
-{{= op.name }} =
+{{= op.name }} : {{? op.input }}{{~ op.input.members :m }}{{= m.value.type }} -> {{~}}{{?}}Http.Request {{= op.output.type }}
+{{= op.name }} {{? op.input }}{{~ op.input.members :m }}{{= m.key }} {{~}}{{?}}=
     Http.request
         { method = "{{= op.http.method }}"
         , headers = []
         , url = "{{= op.http.requestUri }}"
-        , body = Http.emptyBody
+        , body = Http.emptyBody -- TODO: replace with op.input encoded as json
         , expect = Http.expectJson {{= op.output.decoder }}
         , timeout = Nothing
         , withCredentials = False
@@ -51,7 +57,7 @@ import Json.Decode.Pipeline as JDP
 {{~ it.types.filter(t => t.exposeAs) :t }}
 {{= t.typeDef }}
 
-
+{{? t.decoderDef }}
 {{= t.decoderDef }}
-
+{{?}}
 {{~}}

--- a/templates/defineUnionDoc.dot
+++ b/templates/defineUnionDoc.dot
@@ -1,3 +1,5 @@
-One of
+{{? it.doc }}{{= it.doc }}
+
+{{?}}One of
 {{~ it.enum :val }}
 * `{{= it.name }}_{{= val }}`{{~}}


### PR DESCRIPTION
I'm happy with this one now. I considered a few options for providing request arguments to an operation:

* single parameter request type
* multiple parameters (request type expanded into argument list) with named aliases
* multiple parameters (request type expanded into argument list) without named aliases

I chose the last one. Including the named aliases polluted the type namespace with a bunch of aliases for `String`, `Int`, `Bool` etc, most of which did not have any additional documentation. This also complicated the generation script.

Instead of using named aliases, I just used the basic types `String`, `Int`, etc. and added additional documentation for the operation to better label the parameters.

<img width="413" alt="screen shot 2017-02-12 at 12 41 57 pm" src="https://cloud.githubusercontent.com/assets/22655/22864503/ac1274be-f120-11e6-8c3a-844066326029.png">
