### PR TITLE
Prevent top-level packages from repeating in elm-package.json

### DIFF
--- a/templates/elmPackage.dot
+++ b/templates/elmPackage.dot
@@ -6,9 +6,9 @@
     "source-directories": [
         "src"
     ],
-    "exposed-modules": [{{~ it :source }}
+    "exposed-modules": [
       "AWS.Enum",
-      "AWS.Signers.V4",
+      "AWS.Signers.V4",{{~ it :source }}
       "AWS.Services.{{= source.mod }}",{{~}}
       "AWS"
     ],


### PR DESCRIPTION
Small bug fix.

Current `elm-package.json` output:

```
code/aws-sdk-elm [master] » cat elm-package.json
{
    "version": "1.0.0",
    "summary": "AWS SDK for elm",
    "repository": "https://github.com/ktonon/aws-sdk-elm.git",
    "license": "Apache-2.0",
    "source-directories": [
        "src"
    ],
    "exposed-modules": [
      "AWS.Enum",
      "AWS.Signers.V4",
      "AWS.Services.ACM",
      "AWS.Enum",
      "AWS.Signers.V4",
      "AWS.Services.APIGateway",
      "AWS.Enum",
      "AWS.Signers.V4",
      "AWS.Services.ApplicationAutoScaling",
      "AWS.Enum",
      "AWS.Signers.V4",
      "AWS.Services.AppStream",

```

After fix:

```
code/aws-sdk-elm [fix-elm-package-json] » cat elm-package.json
{
    "version": "1.0.0",
    "summary": "AWS SDK for elm",
    "repository": "https://github.com/ktonon/aws-sdk-elm.git",
    "license": "Apache-2.0",
    "source-directories": [
        "src"
    ],
    "exposed-modules": [
      "AWS.Enum",
      "AWS.Signers.V4",
      "AWS.Services.ACM",
      "AWS.Services.APIGateway",
      "AWS.Services.ApplicationAutoScaling",
      "AWS.Services.AppStream",
      "AWS.Services.AutoScaling",
      "AWS.Services.Batch",
      "AWS.Services.Budgets",
      "AWS.Services.CloudDirectory",
      "AWS.Services.CloudFormation",
      "AWS.Services.CloudFront",
```