### PR TITLE
Required operation input as direct function parameters

### DIFF
--- a/scripts/util/render.js
+++ b/scripts/util/render.js
@@ -14,15 +14,17 @@ render.enum = sh => Object.assign({
 
 render.enumDoc = dots.defineUnionDoc;
 
-const memberType = ({ key, value }) =>
-  `${key} : ${value.type}`;
+const memberType = ({ required, key, value }) => (
+  required
+    ? `${key} : ${value.type}`
+    : `${key} : Maybe ${value.type}`
+);
 
-const memberDecoder = ({ required, key, value }) =>
-  [
-    `JDP.${required ? 'required' : 'optional'}`,
-    `"${key}"`,
-    `${value.decoder}`,
-  ].join(' ');
+const memberDecoder = ({ required, key, value }) => (
+  required
+    ? `JDP.required "${key}" ${value.decoder}`
+    : `JDP.optional "${key}" (JD.nullable ${value.decoder}) Nothing`
+);
 
 render.structure = sh => Object.assign({
   exposeAs: sh.category !== 'request' ? sh.type : null,

--- a/scripts/util/resolve-types.js
+++ b/scripts/util/resolve-types.js
@@ -111,7 +111,7 @@ module.exports = (shapesWithoutNames, { inputShapes, outputShapes }) => {
       type: sh.name,
       decoder: `${lowCam(sh.name)}Decoder`,
       members: Object.keys(sh.members).map(key => ({
-        required: true,
+        required: sh.required && sh.required.indexOf(key) !== -1,
         key: safeIdentifier(lowCam(key)),
         value: resolve.shape(sh.members[key]),
       })),

--- a/src/AWS/Http.elm
+++ b/src/AWS/Http.elm
@@ -1,6 +1,5 @@
 module AWS.Http exposing (..)
 
-import AWS exposing (Credentials, ServiceConfig)
 import Json.Encode as JE
 import Json.Decode as JD
 import Http
@@ -14,11 +13,9 @@ type RequestParams
 
 type alias UnsignedRequest a =
     { method : String
-    , headers : List ( String, String )
     , path : String
     , params : RequestParams
     , decoder : JD.Decoder a
-    , config : ServiceConfig
     }
 
 
@@ -28,29 +25,23 @@ unsignedRequest :
     -> String
     -> RequestParams
     -> JD.Decoder a
-    -> ServiceConfig
     -> UnsignedRequest a
-unsignedRequest target method uri params decoder config =
+unsignedRequest target method uri params decoder =
     UnsignedRequest
         method
-        [ ( "Host", config.host ++ ":443" )
-        , ( "X-Amz-Target", config.xAmzTargetPrefix ++ target )
-        , ( "Content-Type", jsonContentType config )
-        ]
         uri
         params
         decoder
-        config
 
 
-url : UnsignedRequest a -> String
-url req =
-    "https://" ++ req.config.host ++ req.path ++ (queryString req)
+url : String -> String -> RequestParams -> String
+url host path params =
+    "https://" ++ host ++ path ++ (queryString params)
 
 
-queryString : UnsignedRequest a -> String
-queryString req =
-    case req.params of
+queryString : RequestParams -> String
+queryString params =
+    case params of
         QueryParams params ->
             params
                 |> List.foldl
@@ -64,16 +55,11 @@ queryString req =
             ""
 
 
-body : UnsignedRequest a -> Http.Body
-body req =
-    case req.params of
+body : RequestParams -> Http.Body
+body params =
+    case params of
         JsonBody value ->
             Http.jsonBody value
 
         _ ->
             Http.emptyBody
-
-
-jsonContentType : ServiceConfig -> String
-jsonContentType config =
-    "application/x-amz-json-" ++ config.xAmzJsonVersion ++ "; charset=utf-8"

--- a/templates/defineOperation.dot
+++ b/templates/defineOperation.dot
@@ -1,13 +1,19 @@
 {-| {{= it.doc }}
-{{? it.input && it.input.members }}
-__Parameters__
+{{? it.requiredParams }}
+__Required Parameters__
 
-{{~ it.input.members :m }}* `{{= m.key }}` __:__ `{{= m.value.type }}`
+{{~ it.requiredParams :p }}* `{{= p.key }}` __:__ `{{= p.value.type }}`
 {{~}}
 {{?}}
 -}
-{{= it.name }} : {{? it.input }}{{~ it.input.members :m }}{{= m.value.type }} -> {{~}}{{?}}AWS.ServiceConfig -> AWS.Http.UnsignedRequest {{= it.output.type }}
-{{= it.name }} {{? it.input }}{{~ it.input.members :m }}{{= m.key }} {{~}}{{?}}serviceConfig =
+{{= it.name }} :
+    {{~ it.requiredParams :p }}{{= p.value.type }}
+    -> {{~}}{{? it.optionalParams.length }}({{= it.optionsName }} -> {{= it.optionsName }})
+    -> {{?}}AWS.Http.UnsignedRequest {{= it.output.type }}
+{{= it.name }} {{~ it.requiredParams :p }}{{= p.key }} {{~}}{{? it.optionalParams.length }}setOptions {{?}}={{? it.optionalParams.length }}
+  let
+    options = setOptions ({{= it.optionsName }} {{= it.optionalParams.map(() => 'Nothing').join(' ') }})
+  in{{?}}
     AWS.Http.unsignedRequest
         "{{= it.name[0].toUpperCase() }}{{= it.name.slice(1) }}"
         "{{= it.http.method }}"
@@ -20,4 +26,11 @@ __Parameters__
             JE.null
         ){{?}}
         {{= it.output.decoder }}
-        serviceConfig
+{{? it.optionalParams.length }}
+
+{-| Options for a {{= it.name }} request
+-}
+type alias {{= it.optionsName }} =
+    { {{= it.optionalParams.map(p => `${p.key} : Maybe ${p.value.type}`).join('\n    , ') }}
+    }
+{{?}}


### PR DESCRIPTION
Optionals grouped into separate record.

Also, service config no longer needed until signing phase.

<img width="519" alt="screen shot 2017-02-18 at 10 17 10 pm" src="https://cloud.githubusercontent.com/assets/22655/23098932/a43eef6c-f628-11e6-900e-e5bf1f102d72.png">

Example usage:

```elm
getObject "bucket"
    "key"
    (\opt ->
        { opt
            | ifMatch = Just "some value"
            , ifNoneMatch = Just "some value"
        }
    )
```