### PR TITLE
Json encoders for all types (WIP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,42 +7,43 @@ __Experimental: Work in progress__
 
 This repo contains scripts which read and translate the AWS SDK [apis/*.json][] files into an elm package. Eventually the generated code will be published to the elm package repository.
 
-## Goals
-
-These are the project goals:
-
-* Make this a pure elm implementation of the AWS SDK (no falling back to JavaScript AWS SDK)
-* Fully generated. No patching after the generation script is run.
-
 ## Preview Docs
 
 * Download [docs.json](https://s3.amazonaws.com/aws-sdk-elm/docs.json)
 * Use [Elm Packages Doc Preview](http://package.elm-lang.org/help/docs-preview)
 
-## Todo
-
-* [x] parse [apis/*.json][] files to get list of AWS APIs
-* [x] generate one elm module per AWS API
-  * [x] module documentation
-* [ ] means to provide AWS credentials
-* [ ] generate AWS operations as elm functions
-  * [x] function name
-  * [x] function documentation
-  * [x] function signature
-  * [x] decode response
-  * [ ] encode request body
-  * [ ] authentication header
-* [ ] generate AWS shapes as elm unions and records
-  * [x] type name
-  * [x] type documentation
-  * [x] record type signature
-  * [x] union type signature
-  * [x] better handling of non-string union types
-  * [ ] handle recursive types (like dynamodb `AttributeValue`)
-* [ ] misc.
-  * [ ] handle blob types
-  * [ ] share common shapes as types between modules?
-  * [ ] integration tests?
-
 [apis/*.json]:https://github.com/aws/aws-sdk-js/tree/master/apis
 [AWS SDK for JavaScript]:https://github.com/aws/aws-sdk-js
+
+## Status
+
+This section describes the current state of support for various AWS services. In time we aim to fix all of these issues.
+
+__Protocols__
+
+AWS services are divided up into the following protocols:
+
+* __query__ -  used by `autoscaling`, `cloudformation`, `cloudsearch`, `elasticache`, `elasticbeanstalk`, `elasticloadbalancing`, `elasticloadbalancingv2`, `email`, `iam`, `importexport`, `monitoring`, `rds`, `redshift`, `sdb`, `sns`, `sqs`, `sts`
+* __json__ - used by `acm`, `application-autoscaling`, `appstream`, `budgets`, `cloudhsm`, `cloudtrail`, `cloudbuild`, `codecommit`, `codedeploy`, `codepipeline`, `cognito-identity`, `cognito-idp`, `config`, `cur`, `datapipeline`, `devicefarm`, `directconnect`, `discovery`, `dms`, `ds`, `dynamodb`, `ecr`, `ecs`, `elasticmapreduce`, `events`, `firehose`, `gamelift`, `health`, `inspector`, `kinesis`, `kinesisanalytics`, `kms`, `lightsail`, `logs`, `machinelearning`, `marketplacecommerceanalytics`, `meteringmarketplace`, `opsworks`, `opsworksscm`, `rekognition`, `route53domains`, `servicecatalog`, `shield`, `sms`, `snowball`, `ssm`, `states`, `storagegateway`, `streams.dynamodb`, `support`, `swf`, `waf`, `waf-regional`, `workspaces`
+* __rest-json__ - used by `apigateway`, `batch`, `clouddirectory`, `cloudsearchdomain`, `cognito-sync`, `elasticfilesystem`, `elastictranscoder`, `es`, `glacier`, `iot`, `iot-data`, `lambda`, `mobileanalytics`, `polly`, `xray`
+* __rest-xml__ - used by `cloudfront`, `route53`
+* __ec2__ - used by `ec2`
+
+We are currently adding support for each of these protocols. Support will be added in the same order in which these protocols appear above.
+
+__Signature Versions__
+
+AWS services are divided up into the following protocols:
+
+* __v4__ - most services
+* __s3__ - only used by `s3`
+* __v2__ - only used by `importexport` and `sdb`
+
+We currently only support __v4__ but plan on adding support for __s3__ soon. Eventually __v2__ support will be added, but it is not high priority.
+
+__Other limitations__
+
+We are actively working on solving the following issues:
+
+* __Recursive types__ (#10) - Affects `dynamodb` and `elasticmap`
+* __Blob types__ (#29) - Affects `acm`, `apigateway`, `clouddirectory`, `cloudsearchdomain`, `cloudtrail`, `codecommit`, `directconnect`, `dms`, `dynamodb`, `ec2`, `ecr`, `email`, `firehose`, `glacier`, `iam`, `iot-data`, `kinesis`, `kms`, `lambda`, `polly`, `rekognition`, `s3`, `sns`, `sqs`, `streams.dynamodb`, `support`, `waf`, `waf-regional`

--- a/demo/Main.elm
+++ b/demo/Main.elm
@@ -60,7 +60,7 @@ update msg model =
         GotDate date ->
             ( model
             , Service.listQueues (\x -> x)
-                |> AWS.signV4 (Service.config Config.region) creds date
+                |> AWS.sign (Service.config Config.region) creds date
                 |> Result.map (Http.send GotResult)
                 |> Result.withDefault Cmd.none
             )

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "clean": "rm -rf src/AWS/Services/*.elm",
     "build:crypto": "webpack",
-    "build": "npm run clean && npm run build:crypto && node scripts/generate-sdk.js && elm package install -y && elm make --docs=docs.json",
+    "build:gen": "node scripts/generate-sdk.js",
+    "build:docs": "elm package install -y && elm make --docs=docs.json",
+    "build": "npm run clean && npm run build:crypto && npm run build:gen && npm run build:docs",
+    "prepublish": "elm format src/AWS/Services --yes",
     "test": "npm run build && elm test",
     "posttest": "eslint ."
   },

--- a/scripts/process-service.js
+++ b/scripts/process-service.js
@@ -70,6 +70,7 @@ module.exports = (data) => {
   const context = {
     categories,
     documentation: data.documentation,
+    extraImports: unique(sumExtraImports),
     isRegional: !data.metadata.globalEndpoint,
     metadata: data.metadata,
     mod,
@@ -79,8 +80,8 @@ module.exports = (data) => {
         : [op.name]),
       []),
     operations: operations.map(dots.defineOperation),
+    signatureVersion: `${upCam(data.metadata.signatureVersion)}Signature`,
     types,
-    extraImports: unique(sumExtraImports),
   };
 
   fs.writeFileSync(

--- a/scripts/process-service.js
+++ b/scripts/process-service.js
@@ -32,7 +32,8 @@ module.exports = (data) => {
         : [];
       const requiredParams = params.filter(m => m.required);
       const optionalParams = params.filter(m => !m.required);
-      const { requestPath, extraImports } = replacePathParams(op.http.requestUri, params);
+      const { requestPath, extraImports, unusedParams } =
+        replacePathParams(op.http.requestUri, requiredParams);
       (extraImports || []).forEach(extraImport => sumExtraImports.push(extraImport));
 
       if (!op.http) {
@@ -45,6 +46,7 @@ module.exports = (data) => {
         http: op.http,
         requestPath,
         requiredParams,
+        requiredUnusedParams: unusedParams,
         optionalParams,
         input: op.input && types.findByShape(op.input.shape),
         output: op.output

--- a/scripts/process-service.js
+++ b/scripts/process-service.js
@@ -46,6 +46,7 @@ module.exports = (data) => {
         requestPath,
         requiredParams,
         optionalParams,
+        input: op.input && types.findByShape(op.input.shape),
         output: op.output
           ? types.findByShape(op.output.shape)
           : { type: '()', decoder: '(JD.succeed ())' },

--- a/scripts/process-service.js
+++ b/scripts/process-service.js
@@ -41,6 +41,8 @@ module.exports = (data) => {
       }
       return {
         name: lowCam(key),
+        actionName: upCam(key),
+        protocol: data.metadata.protocol,
         optionsName: `${key}Options`,
         doc: op.documentation,
         http: op.http,

--- a/scripts/util/render.js
+++ b/scripts/util/render.js
@@ -26,16 +26,12 @@ const memberDecoder = ({ required, key, value }) => (
     : `JDP.optional "${key}" (JD.nullable ${value.decoder}) Nothing`
 );
 
-const memberEncoder = ({ required, key, value }) => (
-  required
-    ? `(::) ( "${key}", data.${key} |> (${value.encoder}) )`
-    : `AWS.Encode.optionalMember (${value.encoder}) ( "${key}", data.${key} )`);
-
 render.structure = sh => Object.assign({
   exposeAs: sh.category !== 'request' ? sh.type : null,
   typeDef: dots.defineRecordType(Object.assign({ memberType }, sh)),
   decoderDef: dots.defineRecordDecoder(Object.assign({ memberDecoder }, sh)),
-  encoderDef: dots.defineRecordEncoder(Object.assign({ memberEncoder }, sh)),
+  jsonEncoderDef: dots.defineRecordJsonEncoder(sh),
+  queryEncoderDef: dots.defineRecordQueryEncoder(sh),
 }, sh);
 
 module.exports = render;

--- a/scripts/util/render.js
+++ b/scripts/util/render.js
@@ -26,10 +26,16 @@ const memberDecoder = ({ required, key, value }) => (
     : `JDP.optional "${key}" (JD.nullable ${value.decoder}) Nothing`
 );
 
+const memberEncoder = ({ required, key, value }) => (
+  required
+    ? `(::) ( "${key}", data.${key} |> (${value.encoder}) )`
+    : `AWS.Encode.optionalMember (${value.encoder}) ( "${key}", data.${key} )`);
+
 render.structure = sh => Object.assign({
   exposeAs: sh.category !== 'request' ? sh.type : null,
   typeDef: dots.defineRecordType(Object.assign({ memberType }, sh)),
   decoderDef: dots.defineRecordDecoder(Object.assign({ memberDecoder }, sh)),
+  encoderDef: dots.defineRecordEncoder(Object.assign({ memberEncoder }, sh)),
 }, sh);
 
 module.exports = render;

--- a/scripts/util/resolve-types.js
+++ b/scripts/util/resolve-types.js
@@ -28,12 +28,14 @@ module.exports = (shapesWithoutNames, { inputShapes, outputShapes }) => {
     type: 'Bool',
     decoder: `${jsonDecode}.bool`,
     encoder: `${jsonEncode}.bool`,
+    toQueryArg: 'toString',
   });
 
   resolve.float = () => render.nothing({
     type: 'Float',
     decoder: `${jsonDecode}.float`,
     encoder: `${jsonEncode}.float`,
+    toQueryArg: 'toString',
   });
 
   resolve.double = resolve.float;
@@ -42,6 +44,7 @@ module.exports = (shapesWithoutNames, { inputShapes, outputShapes }) => {
     type: 'Int',
     decoder: `${jsonDecode}.int`,
     encoder: `${jsonEncode}.int`,
+    toQueryArg: 'toString',
   });
 
   resolve.long = resolve.integer;
@@ -52,6 +55,7 @@ module.exports = (shapesWithoutNames, { inputShapes, outputShapes }) => {
       type: `(List ${child.type})`,
       decoder: `(${jsonDecode}.list ${child.decoder})`,
       encoder: `(List.map (${child.encoder})) >> ${jsonEncode}.list`,
+      toQueryArg: 'NOT SUPPORTED',
     });
   };
 
@@ -73,6 +77,7 @@ module.exports = (shapesWithoutNames, { inputShapes, outputShapes }) => {
         type: `(Dict Float ${value.type})`,
         decoder: `(JDX.dict2 ${jsonDecode}.float ${value.decoder})`,
         encoder: `AWS.Enum.toFloat >> Result.withDefault 0.0 >> ${jsonEncode}.float`,
+        toQueryArg: 'AWS.Enum.toFloat >> Result.withDefault 0.0 >> toString',
         extraImports: [
           'import AWS.Enum',
           'import Dict exposing (Dict)',
@@ -83,6 +88,7 @@ module.exports = (shapesWithoutNames, { inputShapes, outputShapes }) => {
         type: `(Dict String ${value.type})`,
         decoder: `(${jsonDecode}.dict ${value.decoder})`,
         encoder: `AWS.Enum.toString >> Result.withDefault "" >> ${jsonEncode}.string`,
+        toQueryArg: 'AWS.Enum.toString >> Result.withDefault ""',
         extraImports: [
           'import AWS.Enum',
           'import Dict exposing (Dict)',
@@ -96,6 +102,7 @@ module.exports = (shapesWithoutNames, { inputShapes, outputShapes }) => {
       type: 'String',
       decoder: `${jsonDecode}.string`,
       encoder: `${jsonEncode}.string`,
+      toQueryArg: '\\x -> x',
     }));
 
   resolve.blob = resolve.string; // TODO:
@@ -104,6 +111,7 @@ module.exports = (shapesWithoutNames, { inputShapes, outputShapes }) => {
     type: 'Date',
     decoder: 'JDX.date',
     encoder: `toUtcIsoString >> ${jsonEncode}.string`,
+    toQueryArg: 'toUtcIsoString',
     extraImports: [
       'import Date exposing (Date)',
       'import Date.Extra exposing (toUtcIsoString)',
@@ -115,6 +123,7 @@ module.exports = (shapesWithoutNames, { inputShapes, outputShapes }) => {
     type: sh.name,
     decoder: `${lowCam(sh.name)}Decoder`,
     encoder: `AWS.Enum.toString >> Result.withDefault "" >> ${jsonEncode}.string`,
+    toQueryArg: 'AWS.Enum.toString >> Result.withDefault ""',
     extraImports: [
       'import AWS.Enum',
     ],
@@ -129,6 +138,7 @@ module.exports = (shapesWithoutNames, { inputShapes, outputShapes }) => {
       type: sh.name,
       decoder: `${lowCam(sh.name)}Decoder`,
       encoder: `${lowCam(sh.name)}Encoder`,
+      toQueryArg: 'NOT SUPPORTED',
       extraImports: [
         'import AWS.Encode',
       ],

--- a/src/AWS.elm
+++ b/src/AWS.elm
@@ -8,7 +8,7 @@ __Experimental: Work in progress__
 
 ## Request Signing
 
-@docs Request, SignedRequest, signV4
+@docs Request, SignedRequest, sign
 
 -}
 
@@ -86,15 +86,20 @@ type alias SignedRequest a =
 
 {-| Sign an unsigned request, given the current time
 -}
-signV4 :
+sign :
     ServiceConfig
     -> Credentials
     -> Date
     -> Request a
     -> Result String (SignedRequest a)
-signV4 serviceConfig credentials date req =
+sign serviceConfig credentials date req =
     case
         ( serviceConfig, credentials, req )
     of
         ( ServiceConfig config, Credentials creds, UnsignedRequest unsignedReq ) ->
-            AWS.Signers.V4.sign config creds date unsignedReq
+            case config.signatureVersion of
+                AWS.Config.V4Signature ->
+                    AWS.Signers.V4.sign config creds date unsignedReq
+
+                _ ->
+                    Debug.crash "Unsupported signature"

--- a/src/AWS/Config.elm
+++ b/src/AWS/Config.elm
@@ -25,9 +25,16 @@ type Endpoint
     | GlobalEndpoint Host
 
 
+type SignatureVersion
+    = V4Signature
+    | V2Signature
+    | S3Signature
+
+
 type alias Service =
     { serviceName : String
     , endpoint : Endpoint
+    , signatureVersion : SignatureVersion
     , version : String
     , xAmzJsonVersion : Maybe String
     , xAmzTargetPrefix : String

--- a/src/AWS/Encode.elm
+++ b/src/AWS/Encode.elm
@@ -3,6 +3,7 @@ module AWS.Encode exposing (..)
 import Char
 import Hex
 import Http
+import Json.Encode as JE
 import Regex exposing (regex, HowMany(All))
 
 
@@ -40,3 +41,17 @@ uri x =
                         )
                     |> Maybe.withDefault ""
             )
+
+
+optionalMember :
+    (a -> JE.Value)
+    -> ( String, Maybe a )
+    -> List ( String, JE.Value )
+    -> List ( String, JE.Value )
+optionalMember encode ( key, maybeValue ) members =
+    case maybeValue of
+        Nothing ->
+            members
+
+        Just value ->
+            ( key, encode value ) :: members

--- a/src/AWS/Encode.elm
+++ b/src/AWS/Encode.elm
@@ -44,10 +44,10 @@ uri x =
 
 
 optionalMember :
-    (a -> JE.Value)
+    (a -> b)
     -> ( String, Maybe a )
-    -> List ( String, JE.Value )
-    -> List ( String, JE.Value )
+    -> List ( String, b )
+    -> List ( String, b )
 optionalMember encode ( key, maybeValue ) members =
     case maybeValue of
         Nothing ->

--- a/src/AWS/Signers/V4.elm
+++ b/src/AWS/Signers/V4.elm
@@ -1,7 +1,7 @@
 module AWS.Signers.V4 exposing (..)
 
 import AWS.Config exposing (Credentials)
-import AWS.Http exposing (RequestParams, UnsignedRequest)
+import AWS.Http exposing (QueryParams, RequestBody(..), UnsignedRequest)
 import AWS.Signers.Canonical exposing (canonical, signedHeaders)
 import Date exposing (Date)
 import Date.Extra exposing (toUtcIsoString)
@@ -27,8 +27,8 @@ sign config creds date req =
                 |> addAuthorization config creds date req
                 |> addSessionToken creds
                 |> List.map (\( key, val ) -> Http.header key val)
-        , url = AWS.Http.url config.endpoint req.path req.params
-        , body = AWS.Http.body req.params
+        , url = AWS.Http.url config.endpoint req.path req.query
+        , body = AWS.Http.body req.body
         , expect = Http.expectJson req.decoder
         , timeout = Nothing
         , withCredentials = False
@@ -44,6 +44,7 @@ algorithm =
 headers : AWS.Config.Service -> List ( String, String )
 headers config =
     [ ( "Host", AWS.Http.host config.endpoint )
+    , ( "Accept", "application/json" )
     , ( "Content-Type", jsonContentType config )
     ]
 
@@ -94,7 +95,7 @@ authorization :
 authorization creds date config req headers =
     let
         canon =
-            canonical req.method req.path headers req.params
+            canonical req.method req.path headers req.query req.body
 
         scope =
             credentialScope date creds config

--- a/templates/api.dot
+++ b/templates/api.dot
@@ -46,6 +46,7 @@ config {{? it.isRegional }}region {{?}}=
     AWS.Config.Service
         "{{= it.metadata.endpointPrefix }}"
         (AWS.Config.{{= it.isRegional ? `RegionalEndpoint "${it.metadata.endpointPrefix}" region` : `GlobalEndpoint "${it.metadata.globalEndpoint}"` }})
+        AWS.Config.{{= it.signatureVersion }}
         "{{= it.metadata.apiVersion }}"
         {{= it.metadata.jsonVersion ? `(Just "${it.metadata.jsonVersion}")` : 'Nothing' }}
         "AWS{{= it.metadata.endpointPrefix.toUpperCase() }}_{{= it.metadata.apiVersion.replace(/-/g, '') }}."

--- a/templates/api.dot
+++ b/templates/api.dot
@@ -32,6 +32,7 @@ module AWS.Services.{{= it.mod }}
 
 import AWS
 import AWS.Config
+import AWS.Encode
 import AWS.Http
 import Json.Decode as JD
 import Json.Decode.Pipeline as JDP
@@ -64,14 +65,20 @@ config {{? it.isRegional }}region {{?}}=
 {{? t.decoderDef }}
 {{= t.decoderDef }}
 {{?}}
-{{? t.encoderDef }}
-{{= t.encoderDef }}
-{{?}}
 {{~}}
+
+
 {{~ it.types.filter(t => t.category === 'request') :t }}
 {{= t.typeDef }}
+{{~}}
 
-{{? t.encoderDef }}
-{{= t.encoderDef }}
+
+{{~ it.types.filter(t => t.exposeAs || t.category === 'request') :t }}
+{{? it.metadata.protocol === 'json' && t.jsonEncoderDef }}
+{{= t.jsonEncoderDef }}
+{{?}}
+
+{{? it.metadata.protocol === 'query' && t.queryEncoderDef }}
+{{= t.queryEncoderDef }}
 {{?}}
 {{~}}

--- a/templates/api.dot
+++ b/templates/api.dot
@@ -67,3 +67,10 @@ config {{? it.isRegional }}region {{?}}=
 {{= t.encoderDef }}
 {{?}}
 {{~}}
+{{~ it.types.filter(t => t.category === 'request') :t }}
+{{= t.typeDef }}
+
+{{? t.encoderDef }}
+{{= t.encoderDef }}
+{{?}}
+{{~}}

--- a/templates/api.dot
+++ b/templates/api.dot
@@ -63,4 +63,7 @@ config {{? it.isRegional }}region {{?}}=
 {{? t.decoderDef }}
 {{= t.decoderDef }}
 {{?}}
+{{? t.encoderDef }}
+{{= t.encoderDef }}
+{{?}}
 {{~}}

--- a/templates/defineOperation.dot
+++ b/templates/defineOperation.dot
@@ -33,8 +33,12 @@ __Required Parameters__
             "{{= it.http.method }}"
             {{= it.requestPath }}
 
-            {{? it.protocol === 'query' && it.input }}
-            ({{= it.input.queryEncoder("") }} requestInput [])
+            {{? it.protocol === 'query' }}
+            ([("Action", "{{= it.actionName }}")]
+            {{? it.input }}
+                |> {{= it.input.queryEncoder("") }} requestInput
+            {{?}}
+            )
             {{?? true }}
             []
             {{?}}

--- a/templates/defineOperation.dot
+++ b/templates/defineOperation.dot
@@ -6,37 +6,57 @@ __Required Parameters__
 {{~}}
 {{?}}
 -}
-{{= it.name }} :
-    {{~ it.requiredParams :p }}{{= p.value.type }}
-    -> {{~}}{{? it.optionalParams.length }}({{= it.optionsName }} -> {{= it.optionsName }})
-    -> {{?}}AWS.Request {{= it.output.type }}
-{{= it.name }} {{~ it.requiredParams :p }}{{= p.key }} {{~}}{{? it.optionalParams.length }}setOptions {{?}}={{? it.optionalParams.length }}
-  let
-    options = setOptions ({{= it.optionsName }} {{= it.optionalParams.map(() => 'Nothing').join(' ') }})
-  in{{?}}
-    AWS.Http.unsignedRequest
-        "{{= it.name[0].toUpperCase() }}{{= it.name.slice(1) }}"
-        "{{= it.http.method }}"
-        {{= it.requestPath }}
-        ([]
-            |> (::) ( "Action", "{{= it.name[0].toUpperCase() }}{{= it.name.slice(1) }}" ){{? it.http.method === 'GET' }}{{~ it.requiredUnusedParams :p }}
-            |> (::) ( "{{= p.key }}", {{= p.key }} |> ({{= p.value.toQueryArg }}) ){{~}}{{~ it.optionalParams :p }}
-            |> AWS.Encode.optionalMember ({{= p.value.toQueryArg }}) ( "{{= p.key }}", options.{{= p.key }} ){{~}}{{?}}
-        ){{? it.input && it.http.method !== 'GET' }}
-        (({{= it.input.type }}{{~ it.input.members :m }}
-            {{= m.required ? m.key : `options.${m.key}` }}{{~}}
-         )
-            |> {{= it.input.encoder }}
-            |> AWS.Http.JsonBody
-        ){{?? true }}
-        AWS.Http.NoBody{{?}}
-        {{= it.output.decoder }}
-        |> AWS.UnsignedRequest
-{{? it.optionalParams.length }}
 
+{{= it.name }} :
+  {{~ it.requiredParams :p }}
+    {{= p.value.type }} ->
+  {{~}}
+  {{? it.optionalParams.length }}
+    ( {{= it.optionsName }} -> {{= it.optionsName }} ) ->
+  {{?}}
+    AWS.Request {{= it.output.type }}
+
+{{= it.name }} {{~ it.requiredParams :p }}{{= p.key }} {{~}}{{? it.optionalParams.length }}setOptions {{?}}=
+    {{? it.input }}
+    let
+        requestInput = {{= it.input.type }}
+            {{~ it.input.members :m }}
+            {{= m.required ? m.key : `options.${m.key}` }}
+            {{~}}
+        {{? it.optionalParams.length }}
+        options = setOptions ({{= it.optionsName }} {{= it.optionalParams.map(() => 'Nothing').join(' ') }})
+        {{?}}
+    in
+    {{?}}
+        AWS.Http.unsignedRequest
+            "{{= it.actionName }}"
+            "{{= it.http.method }}"
+            {{= it.requestPath }}
+
+            {{? it.protocol === 'query' && it.input }}
+            ({{= it.input.queryEncoder("") }} requestInput [])
+            {{?? true }}
+            []
+            {{?}}
+
+            {{? it.protocol === 'json' && it.input }}
+            (requestInput
+                |> {{= it.input.jsonEncoder }}
+                |> AWS.Http.JsonBody
+            )
+            {{?? true }}
+            AWS.Http.NoBody
+            {{?}}
+
+            {{= it.output.decoder }}
+            |> AWS.UnsignedRequest
+
+
+{{? it.optionalParams.length }}
 {-| Options for a {{= it.name }} request
 -}
 type alias {{= it.optionsName }} =
-    { {{= it.optionalParams.map(p => `${p.key} : Maybe ${p.value.type}`).join('\n    , ') }}
+    {
+    {{= it.optionalParams.map(p => `${p.key} : Maybe ${p.value.type}`).join(',') }}
     }
 {{?}}

--- a/templates/defineOperation.dot
+++ b/templates/defineOperation.dot
@@ -17,18 +17,19 @@ __Required Parameters__
     AWS.Http.unsignedRequest
         "{{= it.name[0].toUpperCase() }}{{= it.name.slice(1) }}"
         "{{= it.http.method }}"
-        {{= it.requestPath }}{{? it.http.method === 'GET' }}
-        (AWS.Http.QueryParams
-            [
-            ]
-        ){{?? it.input }}
+        {{= it.requestPath }}
+        ([]
+            |> (::) ( "Action", "{{= it.name[0].toUpperCase() }}{{= it.name.slice(1) }}" ){{? it.http.method === 'GET' }}{{~ it.requiredUnusedParams :p }}
+            |> (::) ( "{{= p.key }}", {{= p.key }} |> ({{= p.value.toQueryArg }}) ){{~}}{{~ it.optionalParams :p }}
+            |> AWS.Encode.optionalMember ({{= p.value.toQueryArg }}) ( "{{= p.key }}", options.{{= p.key }} ){{~}}{{?}}
+        ){{? it.input && it.http.method !== 'GET' }}
         (({{= it.input.type }}{{~ it.input.members :m }}
             {{= m.required ? m.key : `options.${m.key}` }}{{~}}
          )
             |> {{= it.input.encoder }}
             |> AWS.Http.JsonBody
         ){{?? true }}
-        (AWS.Http.NoParams){{?}}
+        AWS.Http.NoBody{{?}}
         {{= it.output.decoder }}
         |> AWS.UnsignedRequest
 {{? it.optionalParams.length }}

--- a/templates/defineOperation.dot
+++ b/templates/defineOperation.dot
@@ -21,10 +21,14 @@ __Required Parameters__
         (AWS.Http.QueryParams
             [
             ]
+        ){{?? it.input }}
+        (({{= it.input.type }}{{~ it.input.members :m }}
+            {{= m.required ? m.key : `options.${m.key}` }}{{~}}
+         )
+            |> {{= it.input.encoder }}
+            |> AWS.Http.JsonBody
         ){{?? true }}
-        (AWS.Http.JsonBody
-            JE.null
-        ){{?}}
+        (AWS.Http.NoParams){{?}}
         {{= it.output.decoder }}
         |> AWS.UnsignedRequest
 {{? it.optionalParams.length }}

--- a/templates/defineRecordEncoder.dot
+++ b/templates/defineRecordEncoder.dot
@@ -1,5 +1,0 @@
-{{= it.encoder }} : {{= it.type }} -> JE.Value
-{{= it.encoder }} data =
-    []{{~ it.members :m }}
-        |> {{= it.memberEncoder(m) }}{{~}}
-        |> JE.object

--- a/templates/defineRecordEncoder.dot
+++ b/templates/defineRecordEncoder.dot
@@ -1,0 +1,5 @@
+{{= it.encoder }} : {{= it.type }} -> JE.Value
+{{= it.encoder }} data =
+    []{{~ it.members :m }}
+        |> {{= it.memberEncoder(m) }}{{~}}
+        |> JE.object

--- a/templates/defineRecordJsonEncoder.dot
+++ b/templates/defineRecordJsonEncoder.dot
@@ -1,0 +1,13 @@
+{{= it.jsonEncoder }} : {{= it.type }} -> JE.Value
+{{= it.jsonEncoder }} data =
+    []
+        {{~ it.members :m }}
+        {{? m.required }}
+        |> (::) ("{{= m.key }}", data.{{= m.key }} |> ({{= m.value.jsonEncoder }}))
+        {{?? true }}
+        |> AWS.Encode.optionalMember
+            ({{= m.value.jsonEncoder }})
+            ("{{= m.key }}", data.{{= m.key }})
+        {{?}}
+        {{~}}
+        |> JE.object

--- a/templates/defineRecordQueryEncoder.dot
+++ b/templates/defineRecordQueryEncoder.dot
@@ -1,0 +1,15 @@
+{{= it.queryEncoderType }} : {{= it.type }} -> List (String, String)
+{{= it.queryEncoderType }} data =
+    []
+        {{~ it.members :m }}
+        {{? m.required }}
+        |> {{= m.value.queryEncoder(m.key) }} data.{{= m.key }}
+        {{?? true }}
+        |> (case data.{{= m.key }} of
+            Just value ->
+                {{= m.value.queryEncoder(m.key) }} value
+            Nothing ->
+                AWS.Encode.unchangedQueryArgs
+        )
+        {{?}}
+        {{~}}

--- a/tests/HttpTests.elm
+++ b/tests/HttpTests.elm
@@ -2,7 +2,6 @@ module HttpTests exposing (all)
 
 import AWS.Http exposing (..)
 import Expect
-import Json.Encode
 import Test exposing (Test, describe, test)
 
 
@@ -16,34 +15,24 @@ all =
 queryStringTests : Test
 queryStringTests =
     describe "queryString"
-        [ test "NoParams is ignored" <|
+        [ test "An empty list produces an empty string" <|
             \_ ->
-                NoParams
-                    |> queryString
-                    |> Expect.equal ""
-        , test "JsonBody is ignored" <|
-            \_ ->
-                JsonBody Json.Encode.null
-                    |> queryString
-                    |> Expect.equal ""
-        , test "An empty list produces an empty string" <|
-            \_ ->
-                QueryParams []
+                []
                     |> queryString
                     |> Expect.equal ""
         , test "When query params are present they are prefixed with ?" <|
             \_ ->
-                QueryParams [ ( "key", "value" ) ]
+                [ ( "key", "value" ) ]
                     |> queryString
                     |> Expect.equal "?key=value"
         , test "Multiple args are separated with &" <|
             \_ ->
-                QueryParams [ ( "key0", "value0" ), ( "key1", "value1" ) ]
+                [ ( "key0", "value0" ), ( "key1", "value1" ) ]
                     |> queryString
                     |> Expect.equal "?key0=value0&key1=value1"
         , test "Keys and values are uri encoded" <|
             \_ ->
-                QueryParams [ ( "key with spaces", "=&" ) ]
+                [ ( "key with spaces", "=&" ) ]
                     |> queryString
                     |> Expect.equal "?key%20with%20spaces=%3D%26"
         ]

--- a/tests/SignersTests/CanonicalTests.elm
+++ b/tests/SignersTests/CanonicalTests.elm
@@ -31,11 +31,10 @@ canonicalTests =
                     , ( "x-amz-date", "20150830T123600Z" )
                     , ( "host", "  iam.amazonaws.com" )
                     ]
-                    (QueryParams
-                        [ ( "Version", "2010-05-08" )
-                        , ( "Action", "ListUsers" )
-                        ]
-                    )
+                    [ ( "Version", "2010-05-08" )
+                    , ( "Action", "ListUsers" )
+                    ]
+                    NoBody
                 )
                     |> Expect.equal "f536975d06c0309214f805bb90ccff089219ecd68b2577efef23edd43b7e1a59"
         , test "does the same request encoding as http://docs.aws.amazon.com/general/latest/gr/signature-v4-test-suite.html#signature-v4-test-suite-example" <|
@@ -45,11 +44,10 @@ canonicalTests =
                     [ ( "X-Amz-Date", "20150830T123600Z" )
                     , ( "Host", "example.amazonaws.com" )
                     ]
-                    (QueryParams
-                        [ ( "Param1", "value1" )
-                        , ( "Param2", "value2" )
-                        ]
-                    )
+                    [ ( "Param1", "value1" )
+                    , ( "Param2", "value2" )
+                    ]
+                    NoBody
                 )
                     |> Expect.equal "816cd5b414d056048ba4f7c5386d6e0533120fb1fcfa93762cf0fc39e2cf19e0"
         ]
@@ -79,43 +77,37 @@ canonicalUriTests =
 canonicalQueryStringTests : Test
 canonicalQueryStringTests =
     describe "canonicalQueryString"
-        [ test "empty string when no query params are available" <|
+        [ test "empty string when query params is an empty list" <|
             \_ ->
-                JsonBody (JE.string "hello")
-                    |> canonicalQueryString
-                    |> Expect.equal ""
-        , test "empty string when query params is an empty list" <|
-            \_ ->
-                QueryParams []
+                []
                     |> canonicalQueryString
                     |> Expect.equal ""
         , test "sorts by query keys" <|
             \_ ->
-                QueryParams [ ( "bar", "car" ), ( "Foo", "baz" ), ( "alpha", "beta" ) ]
+                [ ( "bar", "car" ), ( "Foo", "baz" ), ( "alpha", "beta" ) ]
                     |> canonicalQueryString
                     |> Expect.equal "Foo=baz&alpha=beta&bar=car"
         , test "encodes a key without a value as key=" <|
             \_ ->
-                QueryParams [ ( "foo", "baz" ), ( "bar", "" ) ]
+                [ ( "foo", "baz" ), ( "bar", "" ) ]
                     |> canonicalQueryString
                     |> Expect.equal "bar=&foo=baz"
         , test "uri encodes keys and values" <|
             \_ ->
-                QueryParams [ ( "one & two", "three=four" ) ]
+                [ ( "one & two", "three=four" ) ]
                     |> canonicalQueryString
                     |> Expect.equal "one%20%26%20two=three%3Dfour"
         , test "does not uri encode 0-9, -, _, ., or ~" <|
             \_ ->
-                QueryParams [ ( "keep-these", "_.~0123456789" ) ]
+                [ ( "keep-these", "_.~0123456789" ) ]
                     |> canonicalQueryString
                     |> Expect.equal "keep-these=_.~0123456789"
         , test "uri encodes all other non-letter characters" <|
             \_ ->
-                QueryParams
-                    [ ( "encode-these"
-                      , " !\"#$%&'()*+,/:;<=>?@[\\]^`{|}"
-                      )
-                    ]
+                [ ( "encode-these"
+                  , " !\"#$%&'()*+,/:;<=>?@[\\]^`{|}"
+                  )
+                ]
                     |> canonicalQueryString
                     |> Expect.equal "encode-these=%20%21%22%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3C%3D%3E%3F%40%5B%5C%5D%5E%60%7B%7C%7D"
         ]
@@ -183,7 +175,7 @@ canonicalPayloadTests =
                         |> expectMatches hexPattern
             , test "hex encodes an empty body" <|
                 \_ ->
-                    QueryParams []
+                    NoBody
                         |> canonicalPayload
                         |> expectMatches hexPattern
             ]

--- a/tests/SignersTests/V4Tests.elm
+++ b/tests/SignersTests/V4Tests.elm
@@ -32,6 +32,7 @@ authorizationTests =
                         AWS.Config.Service
                             "service"
                             (AWS.Config.RegionalEndpoint "service" "us-east-1")
+                            AWS.Config.V4Signature
                             "2015-12-08"
                             (Just "1.1")
                             "AWSACM_20151208."
@@ -141,6 +142,7 @@ conf =
     Service
         "service"
         (RegionalEndpoint "service" "us-east-1")
+        AWS.Config.V4Signature
         ""
         Nothing
         ""


### PR DESCRIPTION
Towards #11.

So my assumption was, that all `GET` requests should provide params and query, and everything else as a json body. This assumption is false.

We need to look at the `metadata.protocol` value. If this is `query`, then query params need to be used.

These are the `protocol`s we have to support:

* __query__ -  used by `autoscaling`, `cloudformation`, `cloudsearch`, `elasticache`, `elasticbeanstalk`, `elasticloadbalancing`, `elasticloadbalancingv2`, `email`, `iam`, `importexport`, `monitoring`, `rds`, `redshift`, `sdb`, `sns`, `sqs`, `sts`
* __json__ - used by `acm`, `application-autoscaling`, `appstream`, `budgets`, `cloudhsm`, `cloudtrail`, `cloudbuild`, `codecommit`, `codedeploy`, `codepipeline`, `cognito-identity`, `cognito-idp`, `config`, `cur`, `datapipeline`, `devicefarm`, `directconnect`, `discovery`, `dms`, `ds`, `dynamodb`, `ecr`, `ecs`, `elasticmapreduce`, `events`, `firehose`, `gamelift`, `health`, `inspector`, `kinesis`, `kinesisanalytics`, `kms`, `lightsail`, `logs`, `machinelearning`, `marketplacecommerceanalytics`, `meteringmarketplace`, `opsworks`, `opsworksscm`, `rekognition`, `route53domains`, `servicecatalog`, `shield`, `sms`, `snowball`, `ssm`, `states`, `storagegateway`, `streams.dynamodb`, `support`, `swf`, `waf`, `waf-regional`, `workspaces`
* __rest-json__ - used by `apigateway`, `batch`, `clouddirectory`, `cloudsearchdomain`, `cognito-sync`, `elasticfilesystem`, `elastictranscoder`, `es`, `glacier`, `iot`, `iot-data`, `lambda`, `mobileanalytics`, `polly`, `xray`
* __rest-xml__ - used by `cloudfront`, `route53`
* __ec2__ - used by `ec2`

These are the signature versions we have to support:

* __v4__ - already implemented, used by most services
* __v2__ - only used by `importexport` and `sdb` (we already skip sdb because the api is not version 2)
* __s3__ - only used by `s3`
