### PR TITLE
Response wrapper and wrapper decoder

### DIFF
--- a/demo/Main.elm
+++ b/demo/Main.elm
@@ -23,12 +23,12 @@ main =
 -- MODEL
 
 
-type alias Response =
+type alias Data =
     Service.ListQueuesResult
 
 
 type alias Model =
-    { val : Maybe Response
+    { response : Maybe (AWS.Response Data)
     , err : Maybe Http.Error
     }
 
@@ -51,7 +51,7 @@ creds =
 
 type Msg
     = GotDate Date
-    | GotResult (Result Http.Error Response)
+    | GotResult (Result Http.Error (AWS.Response Data))
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -67,8 +67,8 @@ update msg model =
 
         GotResult result ->
             case result of
-                Ok val ->
-                    ( { model | val = Just val }, Cmd.none )
+                Ok response ->
+                    ( { model | response = Just response }, Cmd.none )
 
                 Err err ->
                     ( { model | err = Just err }, Cmd.none )
@@ -89,5 +89,18 @@ subscriptions _ =
 
 view : Model -> Html Msg
 view model =
-    div []
-        []
+    ul []
+        (case model.response of
+            Just resp ->
+                resp
+                    |> AWS.responseData
+                    |> .queueUrls
+                    |> Maybe.withDefault []
+                    |> List.map
+                        (\url ->
+                            li [] [ text url ]
+                        )
+
+            Nothing ->
+                []
+        )

--- a/src/AWS.elm
+++ b/src/AWS.elm
@@ -10,9 +10,13 @@ __Experimental: Work in progress__
 
 @docs Request, SignedRequest, sign
 
+## Response
+
+@docs Response, responseData
 -}
 
 import AWS.Config
+import AWS.Decode
 import AWS.Signers.V4 exposing (sign)
 import AWS.Http
 import Date exposing (Date)
@@ -103,3 +107,16 @@ sign serviceConfig credentials date req =
 
                 _ ->
                     Debug.crash "Unsupported signature"
+
+
+{-| Response from an AWS service.
+-}
+type alias Response a =
+    AWS.Decode.ResponseWrapper a
+
+
+{-| Extract the data from the AWS response
+-}
+responseData : Response a -> a
+responseData resp =
+    resp.response.data

--- a/src/AWS/Decode.elm
+++ b/src/AWS/Decode.elm
@@ -1,0 +1,31 @@
+module AWS.Decode exposing (..)
+
+import Json.Decode as JD
+import Json.Decode.Pipeline as JDP
+
+
+type alias ResponseWrapper a =
+    { response : Response a }
+
+
+type alias Response a =
+    { data : a
+    , metadata : Metadata
+    }
+
+
+type alias Metadata =
+    { requestId : String }
+
+
+responseWrapperDecoder : String -> String -> JD.Decoder a -> JD.Decoder (ResponseWrapper a)
+responseWrapperDecoder actionName dataName dataDecoder =
+    JDP.decode ResponseWrapper
+        |> JDP.required (actionName ++ "Response")
+            (JDP.decode Response
+                |> JDP.required dataName dataDecoder
+                |> JDP.required "ResponseMetadata"
+                    (JDP.decode Metadata
+                        |> JDP.required "RequestId" JD.string
+                    )
+            )

--- a/templates/api.dot
+++ b/templates/api.dot
@@ -32,6 +32,7 @@ module AWS.Services.{{= it.mod }}
 
 import AWS
 import AWS.Config
+import AWS.Decode
 import AWS.Encode
 import AWS.Http
 import Json.Decode as JD

--- a/templates/defineOperation.dot
+++ b/templates/defineOperation.dot
@@ -14,7 +14,7 @@ __Required Parameters__
   {{? it.optionalParams.length }}
     ( {{= it.optionsName }} -> {{= it.optionsName }} ) ->
   {{?}}
-    AWS.Request {{= it.output.type }}
+    AWS.Request (AWS.Response {{= it.output.type }})
 
 {{= it.name }} {{~ it.requiredParams :p }}{{= p.key }} {{~}}{{? it.optionalParams.length }}setOptions {{?}}=
     {{? it.input }}
@@ -52,7 +52,7 @@ __Required Parameters__
             AWS.Http.NoBody
             {{?}}
 
-            {{= it.output.decoder }}
+            (AWS.Decode.responseWrapperDecoder "{{= it.actionName }}" "{{= it.output.type }}" {{= it.output.decoder }})
             |> AWS.UnsignedRequest
 
 


### PR DESCRIPTION
Response data comes back looking like this, so the result types and decoders need to be wrapped to handle the extra stuff at the top.

<img width="522" alt="screen shot 2017-03-10 at 10 09 34 pm" src="https://cloud.githubusercontent.com/assets/22655/23820062/45518882-05de-11e7-8156-0b1b5cadabc1.png">
